### PR TITLE
Improve form clarity

### DIFF
--- a/lieferanten.html
+++ b/lieferanten.html
@@ -22,20 +22,37 @@
         </nav>
         <main class="flex-fill p-4">
             <h3>Lieferantenverwaltung</h3>
+            <p class="text-muted">Wählen Sie einen Lieferanten aus, um dessen Details anzuzeigen und zu bearbeiten.</p>
             <div class="row">
                 <div class="col-md-7">
                     <label>Lieferant</label>
                     <select id="lieferant-auswahl" class="form-select mb-3"></select>
                     <div class="row g-2">
-                        <div class="col-md-6"><input id="lieferant-id" class="form-control" readonly placeholder="ID"></div>
-                        <div class="col-md-6"><input id="lieferant-status" class="form-control" readonly placeholder="Status"></div>
-                        <div class="col-md-6"><input id="lieferant-produkte" class="form-control" readonly placeholder="Zugeordnete Produkte"></div>
-                        <div class="col-md-6"><input id="lieferant-bestand" class="form-control" readonly placeholder="Gesamtbestand"></div>
-                        <div class="col-md-12"><input id="lieferant-umsatz" class="form-control bg-danger text-white" readonly placeholder="Umsatz Gesamt"></div>
+                        <div class="col-md-6">
+                            <label for="lieferant-id" class="form-label">ID</label>
+                            <input id="lieferant-id" class="form-control" readonly placeholder="ID">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="lieferant-status" class="form-label">Status</label>
+                            <input id="lieferant-status" class="form-control" readonly placeholder="Status">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="lieferant-produkte" class="form-label">Zugeordnete Produkte</label>
+                            <input id="lieferant-produkte" class="form-control" readonly placeholder="Zugeordnete Produkte">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="lieferant-bestand" class="form-label">Gesamtbestand</label>
+                            <input id="lieferant-bestand" class="form-control" readonly placeholder="Gesamtbestand">
+                        </div>
+                        <div class="col-md-12">
+                            <label for="lieferant-umsatz" class="form-label">Umsatz Gesamt</label>
+                            <input id="lieferant-umsatz" class="form-control" readonly placeholder="Umsatz Gesamt">
+                        </div>
                     </div>
                     <button class="btn btn-outline-primary mt-3 w-100" onclick="toggleLieferantStatus()">Aktivieren / Inaktivieren</button>
-			<div class="mt-3">
+                        <div class="mt-3">
                         <h5>Lieferant bearbeiten</h5>
+                        <label for="edit-lieferant-name" class="form-label">Neuer Name</label>
                         <input id="edit-lieferant-name" class="form-control mb-2" placeholder="Neuer Name">
                         <button class="btn btn-primary w-100 mb-2" onclick="bearbeiteLieferant()">Speichern</button>
                         <button class="btn btn-outline-danger w-100" onclick="loescheLieferant()">Lieferant löschen</button>
@@ -43,7 +60,9 @@
                 </div>
                 <div class="col-md-5">
                     <h5>Neuen Lieferanten anlegen</h5>
+                    <label for="neu-lieferant-name" class="form-label">Lieferantenname</label>
                     <input id="neu-lieferant-name" class="form-control mb-2" placeholder="Lieferantenname">
+                    <label for="neu-lieferant-pw" class="form-label">Kennwort</label>
                     <input id="neu-lieferant-pw" class="form-control mb-2" type="password" placeholder="Kennwort">
                     <button class="btn btn-success w-100" onclick="neuerLieferant()">Bestätigen</button>
                 </div>

--- a/produkte.html
+++ b/produkte.html
@@ -22,6 +22,7 @@
         </nav>
         <main class="flex-fill p-4">
             <h3>Produktverwaltung</h3>
+            <p class="text-muted">Wählen Sie einen Anbieter und ein Produkt aus, um Detailinformationen einzusehen.</p>
             <div class="row">
                 <div class="col-md-7">
                     <label>Anbieter</label>
@@ -29,16 +30,36 @@
                     <label>Produkt</label>
                     <select id="produkt-auswahl" class="form-select mb-3"></select>
                     <div class="row g-2">
-                        <div class="col-md-6"><input id="preis" class="form-control" readonly placeholder="Preis"></div>
-                        <div class="col-md-6"><input id="bestand" class="form-control" readonly placeholder="Verfügbar"></div>
-                        <div class="col-md-6"><input id="verkauft" class="form-control bg-danger text-white" readonly placeholder="Verkauft"></div>
-                        <div class="col-md-6"><input id="umsatz" class="form-control bg-danger text-white" readonly placeholder="Umsatz"></div>
-                        <div class="col-md-6"><input id="verkauf-seit" class="form-control bg-danger text-white" readonly placeholder="Seit Inventur"></div>
-                        <div class="col-md-6"><input id="letzter-verkauf" class="form-control" readonly placeholder="Letzter Verkauf"></div>
+                        <div class="col-md-6">
+                            <label for="preis" class="form-label">Preis</label>
+                            <input id="preis" class="form-control" readonly placeholder="Preis">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="bestand" class="form-label">Verfügbar</label>
+                            <input id="bestand" class="form-control" readonly placeholder="Verfügbar">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="verkauft" class="form-label">Verkauft</label>
+                            <input id="verkauft" class="form-control" readonly placeholder="Verkauft">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="umsatz" class="form-label">Umsatz</label>
+                            <input id="umsatz" class="form-control" readonly placeholder="Umsatz">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="verkauf-seit" class="form-label">Seit Inventur</label>
+                            <input id="verkauf-seit" class="form-control" readonly placeholder="Seit Inventur">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="letzter-verkauf" class="form-label">Letzter Verkauf</label>
+                            <input id="letzter-verkauf" class="form-control" readonly placeholder="Letzter Verkauf">
+                        </div>
                     </div>
                     <div class="mt-3">
                         <h5>Produkt bearbeiten</h5>
+                        <label for="edit-name" class="form-label">Neuer Name</label>
                         <input id="edit-name" class="form-control mb-2" placeholder="Neuer Name">
+                        <label for="edit-preis" class="form-label">Neuer Preis</label>
                         <input id="edit-preis" class="form-control mb-2" type="number" step="0.01" placeholder="Neuer Preis">
                         <button class="btn btn-primary w-100 mb-2" onclick="bearbeiteProdukt()">Speichern</button>
                         <button class="btn btn-outline-danger w-100" onclick="loescheProdukt()">Produkt löschen</button>
@@ -46,7 +67,9 @@
                 </div>
                 <div class="col-md-5">
                     <h5>Neues Produkt anlegen</h5>
+                    <label for="neu-name" class="form-label">Produktname</label>
                     <input id="neu-name" class="form-control mb-2" placeholder="Produktname">
+                    <label for="neu-preis" class="form-label">Preis</label>
                     <input id="neu-preis" class="form-control mb-2" type="number" step="0.01" placeholder="Preis">
                     <button class="btn btn-success w-100" onclick="neuesProdukt()">Bestätigen</button>
                 </div>


### PR DESCRIPTION
## Summary
- add explanatory text and labels to the supplier page
- do the same for the product page and remove red highlight

## Testing
- `npx --yes prettier -c *.html *.css *.js`
- `npx --yes htmlhint index.html`
- `npx --yes htmlhint lieferanten.html produkte.html inventur.html`
- `npx --yes htmlhint *.html`


------
https://chatgpt.com/codex/tasks/task_e_6849527ec638832596218dd94ac145ed