### PR TITLE
Implement supplier document uploads and messaging

### DIFF
--- a/WebNewChanged/README.md
+++ b/WebNewChanged/README.md
@@ -13,3 +13,9 @@ vereinheitlicht das Erscheinungsbild aller Seiten.
 - **Einheitliches Layout:** Alle Bereiche nutzen eine Seitenleiste und
   "Card"-Sektionen für Formulare und Tabellen. Farben und Abstände
   folgen der CI-Vorgabe der Login-Seite.
+- **Dokumentenverwaltung:** Admins können Dateien für Lieferanten
+  hochladen. Lieferanten laden diese in ihrem Postfach herunter.
+- **Chat-Funktion:** Nachrichten vom Admin an Lieferanten werden im
+  Postfach angezeigt.
+- **Neues Postfach:** Die Seite `postfach.html` bündelt Dokumente und
+  Nachrichten pro Lieferant.

--- a/WebNewChanged/inventur.html
+++ b/WebNewChanged/inventur.html
@@ -17,6 +17,7 @@
                 <li class="nav-item"><a href="inventur.html" class="nav-link active">Bestandsabfrage</a></li>
                 <li class="nav-item"><a href="lieferanten.html" class="nav-link">Lieferanten</a></li>
                 <li class="nav-item"><a href="produkte.html" class="nav-link">Produkte</a></li>
+                <li class="nav-item"><a href="postfach.html" class="nav-link">Postfach</a></li>
             </ul>
         </nav>
         <main class="flex-fill p-4">

--- a/WebNewChanged/lieferanten.html
+++ b/WebNewChanged/lieferanten.html
@@ -17,6 +17,7 @@
                 <li class="nav-item"><a href="inventur.html" class="nav-link">Bestandsabfrage</a></li>
                 <li class="nav-item"><a href="lieferanten.html" class="nav-link active">Lieferanten</a></li>
                 <li class="nav-item"><a href="produkte.html" class="nav-link">Produkte</a></li>
+                <li class="nav-item"><a href="postfach.html" class="nav-link">Postfach</a></li>
             </ul>
         </nav>
         <main class="flex-fill p-4">
@@ -58,6 +59,18 @@
                         <button class="btn btn-success w-100 mb-2" onclick="bearbeiteLieferant()">Speichern</button>
                         <button class="btn btn-outline-danger w-100" onclick="loescheLieferant()">Lieferant löschen</button>
                     </div>
+<div class="mt-4">
+    <h5>Dokumente</h5>
+    <input id="dokument-upload" type="file" class="form-control mb-2">
+    <button class="btn btn-success w-100 mb-2" onclick="dokumentHochladen()">Hochladen</button>
+    <ul id="dokument-liste" class="list-group mb-3"></ul>
+</div>
+<div class="mt-4">
+    <h5>Nachricht senden</h5>
+    <textarea id="nachricht-text" class="form-control mb-2" placeholder="Nachricht"></textarea>
+    <button class="btn btn-success w-100 mb-2" onclick="sendeNachricht()">Senden</button>
+    <div id="nachrichten-log" class="border rounded p-2" style="max-height: 200px; overflow-y: auto;"></div>
+</div>
                 </div>
                 <div class="col-md-5">
                     <h5>Neuen Lieferanten anlegen</h5>

--- a/WebNewChanged/postfach.html
+++ b/WebNewChanged/postfach.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Postfach</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <script defer src="script.js"></script>
+</head>
+<body class="bg-light" onload="initPostfach()">
+    <div class="d-flex">
+        <nav class="sidebar p-3">
+            <h5>🍴 Unsre Speis</h5>
+            <ul class="nav flex-column">
+                <li class="nav-item"><a href="inventur.html" class="nav-link">Bestandsabfrage</a></li>
+                <li class="nav-item"><a href="lieferanten.html" class="nav-link">Lieferanten</a></li>
+                <li class="nav-item"><a href="produkte.html" class="nav-link">Produkte</a></li>
+                <li class="nav-item"><a href="postfach.html" class="nav-link active">Postfach</a></li>
+            </ul>
+        </nav>
+        <main class="flex-fill p-4">
+            <div class="container-xl">
+                <h3>Postfach</h3>
+                <p class="text-muted">Wählen Sie Ihren Lieferanten aus, um Nachrichten und Dokumente einzusehen.</p>
+                <div class="bg-card">
+                    <label for="postfach-lieferant" class="form-label">Lieferant</label>
+                    <select id="postfach-lieferant" class="form-select mb-3"></select>
+                    <h5>Nachrichten</h5>
+                    <div id="postfach-nachrichten" class="border rounded p-2 mb-3" style="max-height: 200px; overflow-y: auto;"></div>
+                    <h5>Dokumente</h5>
+                    <ul id="postfach-dokumente" class="list-group"></ul>
+                </div>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/WebNewChanged/produkte.html
+++ b/WebNewChanged/produkte.html
@@ -25,6 +25,9 @@
           <li class="nav-item">
             <a href="produkte.html" class="nav-link active">Produkte</a>
           </li>
+          <li class="nav-item">
+            <a href="postfach.html" class="nav-link">Postfach</a>
+          </li>
         </ul>
       </nav>
       <main class="flex-fill p-4">

--- a/WebNewChanged/script.js
+++ b/WebNewChanged/script.js
@@ -32,21 +32,30 @@ let produkte = [
     bestand: 5,
     verkauf: 3,
     seitInventur: 1,
+
     letzterVerkauf: "2025-06-08 14:22",
     lieferant: "Bauernhof Knafl",
   },
 ];
+let dokumente = {};
+let nachrichten = {};
 
 function loadData() {
   const lsL = localStorage.getItem("lieferanten");
   const lsP = localStorage.getItem("produkte");
+  const lsD = localStorage.getItem("dokumente");
+  const lsN = localStorage.getItem("nachrichten");
   if (lsL) lieferanten = JSON.parse(lsL);
   if (lsP) produkte = JSON.parse(lsP);
+  if (lsD) dokumente = JSON.parse(lsD);
+  if (lsN) nachrichten = JSON.parse(lsN);
 }
 
 function saveData() {
   localStorage.setItem("lieferanten", JSON.stringify(lieferanten));
   localStorage.setItem("produkte", JSON.stringify(produkte));
+  localStorage.setItem("dokumente", JSON.stringify(dokumente));
+  localStorage.setItem("nachrichten", JSON.stringify(nachrichten));
 }
 
 loadData();
@@ -203,6 +212,8 @@ function updateLieferantInfo() {
     " €";
   const edit = document.getElementById("edit-lieferant-name");
   if (edit) edit.value = lieferant.name;
+  zeigeDokumenteAdmin(name);
+  zeigeNachrichtenAdmin(name);
 }
 
 function toggleLieferantStatus() {
@@ -318,3 +329,106 @@ function initInventur() {
   }
   ladeInventurTabelle();
 }
+
+// --- Dokumentenverwaltung ---
+function dokumentHochladen() {
+  const name = document.getElementById("lieferant-auswahl")?.value;
+  const inp = document.getElementById("dokument-upload");
+  if (!name || !inp || !inp.files.length) return;
+  const file = inp.files[0];
+  const reader = new FileReader();
+  reader.onload = () => {
+    if (!dokumente[name]) dokumente[name] = [];
+    dokumente[name].push({ name: file.name, data: reader.result });
+    saveData();
+    inp.value = "";
+    zeigeDokumenteAdmin(name);
+  };
+  reader.readAsDataURL(file);
+}
+
+function zeigeDokumenteAdmin(name) {
+  const list = document.getElementById("dokument-liste");
+  if (!list) return;
+  list.innerHTML = "";
+  (dokumente[name] || []).forEach((doc) => {
+    const li = document.createElement("li");
+    li.className = "list-group-item";
+    const a = document.createElement("a");
+    a.href = doc.data;
+    a.download = doc.name;
+    a.textContent = doc.name;
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+}
+
+// --- Nachrichten ---
+function sendeNachricht() {
+  const name = document.getElementById("lieferant-auswahl")?.value;
+  const textEl = document.getElementById("nachricht-text");
+  const text = textEl?.value.trim();
+  if (!name || !text) return;
+  if (!nachrichten[name]) nachrichten[name] = [];
+  nachrichten[name].push({ text, time: new Date().toLocaleString() });
+  saveData();
+  textEl.value = "";
+  zeigeNachrichtenAdmin(name);
+}
+
+function zeigeNachrichtenAdmin(name) {
+  const box = document.getElementById("nachrichten-log");
+  if (!box) return;
+  box.innerHTML = "";
+  (nachrichten[name] || []).forEach((m) => {
+    const div = document.createElement("div");
+    div.textContent = `[${m.time}] ${m.text}`;
+    box.appendChild(div);
+  });
+}
+
+// --- Postfach ---
+function initPostfach() {
+  const sel = document.getElementById("postfach-lieferant");
+  if (!sel) return;
+  sel.innerHTML = "";
+  lieferanten.forEach((l) => {
+    const opt = document.createElement("option");
+    opt.value = l.name;
+    opt.textContent = l.name;
+    sel.appendChild(opt);
+  });
+  sel.addEventListener("change", () => {
+    zeigeDokumente(sel.value);
+    zeigeNachrichten(sel.value);
+  });
+  sel.dispatchEvent(new Event("change"));
+}
+
+function zeigeDokumente(name) {
+  const list = document.getElementById("postfach-dokumente");
+  if (!list) return;
+  list.innerHTML = "";
+  (dokumente[name] || []).forEach((doc) => {
+    const li = document.createElement("li");
+    li.className = "list-group-item";
+    const a = document.createElement("a");
+    a.href = doc.data;
+    a.download = doc.name;
+    a.textContent = doc.name;
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+}
+
+function zeigeNachrichten(name) {
+  const box = document.getElementById("postfach-nachrichten");
+  if (!box) return;
+  box.innerHTML = "";
+  (nachrichten[name] || []).forEach((m) => {
+    const div = document.createElement("div");
+    div.textContent = `[${m.time}] ${m.text}`;
+    box.appendChild(div);
+  });
+}
+


### PR DESCRIPTION
## Summary
- document upload for suppliers
- admin-to-supplier chat messages
- add new `postfach.html` page for suppliers
- show message/document lists in admin view
- mention new functionality in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686263cbf6a08325ac24abd258da683d